### PR TITLE
Create lifecycle policies for ECR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,19 @@ locals {
   options = {
     for repo, obj in var.repositories : repo => lookup(obj, "options", {})
   }
+  lifecycle_policy = {
+    for repo, obj in var.repositories : repo => {
+      rules = [
+        for rule in lookup(obj, "lifecycle_rules", []) : {
+          rulePriority = index(lookup(obj, "lifecycle_rules", []), rule) + 1
+          action = {
+            type = "expire"
+          }
+          selection = rule
+        }
+      ]
+    }
+  }
 }
 
 resource "aws_ecr_repository" "this" {
@@ -13,4 +26,10 @@ resource "aws_ecr_repository" "this" {
   image_scanning_configuration {
     scan_on_push = lookup(local.options[each.key], "scan_on_push", true)
   }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = var.repositories
+  repository = aws_ecr_repository.this[each.key].name
+  policy     = jsonencode(local.lifecycle_policy[each.key])
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,29 @@
 variable "repositories" {
   description = "A map of repositories"
+  // Setting a default for example purpose
   default     = {
     alpine = {
       options = {
         scan_on_push         = true
         image_tag_mutability = "MUTABLE"
       }
+      // For lifecycle rules please set the structure as described
+      // in the selection section of 
+      // https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html
       lifecycle_rules = [
         {
-          tag_status      = "untagged"
-          tag_prefix_list = []
-          count_type      = "sinceImagePushed"
-          count_number    = "14"
+          tagStatus     = "untagged"
+          // In case of untagged images be sure to not include 
+          // 'tagPrefixList' to avoid failures
+          countType     = "sinceImagePushed"
+          countNumber   = 14
+          countUnit     = "days"
         },
         {
-          tag_status      = "tagged"
-          tag_prefix_list = ["v"]
-          count_type      = "imageCountMoreThan"
-          count_number    = "30"
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 30
         }
       ]
     },
@@ -28,16 +34,16 @@ variable "repositories" {
       }
       lifecycle_rules = [
         {
-          tag_status      = "untagged"
-          tag_prefix_list = []
-          count_type      = "sinceImagePushed"
-          count_number    = "14"
+          tagStatus     = "untagged"
+          countType     = "sinceImagePushed"
+          countNumber   = 14
+          countUnit     = "days"
         },
         {
-          tag_status      = "tagged"
-          tag_prefix_list = ["v"]
-          count_type      = "imageCountMoreThan"
-          count_number    = "30"
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 30
         }
       ]
     }


### PR DESCRIPTION
Code for adding image lifecycle policies

Following code would be applied.

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_lifecycle_policy.this["alpine"] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 14
                          + countType   = "sinceImagePushed"
                          + countUnit   = "days"
                          + tagStatus   = "untagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 2
                      + selection    = {
                          + countNumber   = 30
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "alpine"
    }

  # aws_ecr_lifecycle_policy.this["debian"] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 14
                          + countType   = "sinceImagePushed"
                          + countUnit   = "days"
                          + tagStatus   = "untagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 2
                      + selection    = {
                          + countNumber   = 30
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "debian"
    }

  # aws_ecr_repository.this["alpine"] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "alpine"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # aws_ecr_repository.this["debian"] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "debian"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```