### PR TITLE
Set Repository access policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ locals {
   }
   repo_access = {
     for repo, obj in var.repositories : repo => {
-      read_access = lookup(obj, "read_arns", [])
+      read_access  = lookup(obj, "read_arns", [])
       write_access = lookup(obj, "write_arns", [])
     }
   }
@@ -25,9 +25,9 @@ locals {
 
 data "aws_iam_policy_document" "this" {
   for_each = local.repo_access
-  
+
   statement {
-    sid = "ECRRead"
+    sid    = "ECRRead"
     effect = "Allow"
     actions = [
       "ecr:BatchCheckLayerAvailability",
@@ -35,12 +35,12 @@ data "aws_iam_policy_document" "this" {
       "ecr:GetDownloadUrlForLayer",
     ]
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = lookup(local.repo_access[each.key], "read_access", [])
     }
   }
   statement {
-    sid = "ECRPush"
+    sid    = "ECRPush"
     effect = "Allow"
     actions = [
       "ecr:GetDownloadUrlForLayer",
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "this" {
       "ecr:CompleteLayerUpload"
     ]
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = lookup(local.repo_access[each.key], "write_access", [])
     }
   }
@@ -79,5 +79,5 @@ resource "aws_ecr_repository_policy" "this" {
   for_each = var.repositories
 
   repository = aws_ecr_repository.this[each.key].name
-  policy = data.aws_iam_policy_document.this[each.key].json
+  policy     = data.aws_iam_policy_document.this[each.key].json
 }

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,47 @@ locals {
       ]
     }
   }
+  repo_access = {
+    for repo, obj in var.repositories : repo => {
+      read_access = lookup(obj, "read_arns", [])
+      write_access = lookup(obj, "write_arns", [])
+    }
+  }
+}
+
+data "aws_iam_policy_document" "this" {
+  for_each = local.repo_access
+  
+  statement {
+    sid = "ECRRead"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    principals {
+      type = "AWS"
+      identifiers = lookup(local.repo_access[each.key], "read_access", [])
+    }
+  }
+  statement {
+    sid = "ECRPush"
+    effect = "Allow"
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = lookup(local.repo_access[each.key], "write_access", [])
+    }
+  }
 }
 
 resource "aws_ecr_repository" "this" {
@@ -32,4 +73,11 @@ resource "aws_ecr_lifecycle_policy" "this" {
   for_each   = var.repositories
   repository = aws_ecr_repository.this[each.key].name
   policy     = jsonencode(local.lifecycle_policy[each.key])
+}
+
+resource "aws_ecr_repository_policy" "this" {
+  for_each = var.repositories
+
+  repository = aws_ecr_repository.this[each.key].name
+  policy = data.aws_iam_policy_document.this[each.key].json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,15 @@ variable "repositories" {
           countNumber   = 30
         }
       ]
+      // These ARNS can be accounts that can read repository images or individual IAM users/roles
+      read_arns = [
+        "arn:aws:iam::983456789123:user/test",
+        "arn:aws:iam::123456789101:role/awesome"
+      ]
+      write_arns = [
+        "arn:aws:iam::983456789123:user/test",
+        "arn:aws:iam::123456789101:role/awesome"
+      ]
     },
     debian = {
       options = {
@@ -45,6 +54,14 @@ variable "repositories" {
           countType     = "imageCountMoreThan"
           countNumber   = 30
         }
+      ]
+      read_arns = [
+        "arn:aws:iam::983456789123:user/test",
+        "arn:aws:iam::123456789101:role/awesome"
+      ]
+      write_arns = [
+        "arn:aws:iam::983456789123:user/test",
+        "arn:aws:iam::123456789101:role/awesome"
       ]
     }
   }


### PR DESCRIPTION
Set access to repositories to users or roles or accounts.

Following plan would be applied
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_lifecycle_policy.this["alpine"] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 14
                          + countType   = "sinceImagePushed"
                          + countUnit   = "days"
                          + tagStatus   = "untagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 2
                      + selection    = {
                          + countNumber   = 30
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "alpine"
    }

  # aws_ecr_lifecycle_policy.this["debian"] will be created
  + resource "aws_ecr_lifecycle_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 14
                          + countType   = "sinceImagePushed"
                          + countUnit   = "days"
                          + tagStatus   = "untagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + rulePriority = 2
                      + selection    = {
                          + countNumber   = 30
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "debian"
    }

  # aws_ecr_repository.this["alpine"] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "alpine"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # aws_ecr_repository.this["debian"] will be created
  + resource "aws_ecr_repository" "this" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "debian"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # aws_ecr_repository_policy.this["alpine"] will be created
  + resource "aws_ecr_repository_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::123456789101:user/testuser",
                              + "arn:aws:iam::123456789101:user/testing",
                            ]
                        }
                      + Sid       = "ECRRead"
                    },
                  + {
                      + Action    = [
                          + "ecr:UploadLayerPart",
                          + "ecr:PutImage",
                          + "ecr:InitiateLayerUpload",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:CompleteLayerUpload",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::123456789101:user/testuser",
                              + "arn:aws:iam::123456789101:user/testing",
                            ]
                        }
                      + Sid       = "ECRPush"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + registry_id = (known after apply)
      + repository  = "alpine"
    }

  # aws_ecr_repository_policy.this["debian"] will be created
  + resource "aws_ecr_repository_policy" "this" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::123456789101:user/testuser",
                              + "arn:aws:iam::123456789101:user/testing",
                            ]
                        }
                      + Sid       = "ECRRead"
                    },
                  + {
                      + Action    = [
                          + "ecr:UploadLayerPart",
                          + "ecr:PutImage",
                          + "ecr:InitiateLayerUpload",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:CompleteLayerUpload",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::123456789101:user/testuser",
                              + "arn:aws:iam::123456789101:user/testing",
                            ]
                        }
                      + Sid       = "ECRPush"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + registry_id = (known after apply)
      + repository  = "debian"
    }

Plan: 6 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```